### PR TITLE
IAIF-153: support for ingest-direct 

### DIFF
--- a/core/src/main/java/com/emc/ia/sdk/sip/client/ArchiveClients.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/ArchiveClients.java
@@ -28,6 +28,7 @@ import com.emc.ia.sdk.support.datetime.DefaultClock;
 import com.emc.ia.sdk.support.http.HttpClient;
 import com.emc.ia.sdk.support.http.apache.ApacheHttpClient;
 import com.emc.ia.sdk.support.io.RuntimeIoException;
+import com.emc.ia.sdk.support.rest.LinkContainer;
 import com.emc.ia.sdk.support.rest.RestClient;
 
 /**
@@ -159,6 +160,7 @@ public final class ArchiveClients {
   private static void cacheResourceUris(ArchiveOperationsByApplicationResourceCache resourceCache,
       RestClient restClient, Application application) throws IOException {
     Aics aics = restClient.follow(application, InfoArchiveLinkRelations.LINK_AICS, Aics.class);
+    LinkContainer aips = restClient.follow(application, InfoArchiveLinkRelations.LINK_AIPS, LinkContainer.class);
 
     Map<String, String> dipResourceUriByAicName = new HashMap<>();
     aics.getItems()
@@ -166,6 +168,7 @@ public final class ArchiveClients {
     resourceCache.setDipResourceUriByAicName(dipResourceUriByAicName);
     resourceCache.setCiResourceUri(application.getUri(InfoArchiveLinkRelations.LINK_CI));
     resourceCache.setAipResourceUri(application.getUri(InfoArchiveLinkRelations.LINK_AIPS));
+    resourceCache.setAipIngestDirectResourceUri(aips.getUri(InfoArchiveLinkRelations.LINK_INGEST_DIRECT));
   }
 
   private static RestClient createDefaultRestClient() {

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/ArchiveOperationsByApplicationResourceCache.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/ArchiveOperationsByApplicationResourceCache.java
@@ -10,6 +10,7 @@ public class ArchiveOperationsByApplicationResourceCache {
   private final String applicationName;
   private String ciResourceUri;
   private String aipResourceUri;
+  private String aipIngestDirectResourceUri;
   private Map<String, String> dipResourceUriByAicName;
 
   public ArchiveOperationsByApplicationResourceCache(String applicationName) {
@@ -30,6 +31,14 @@ public class ArchiveOperationsByApplicationResourceCache {
 
   public void setAipResourceUri(String aipResourceUri) {
     this.aipResourceUri = aipResourceUri;
+  }
+
+  public String getAipIngestDirectResourceUri() {
+    return aipIngestDirectResourceUri;
+  }
+
+  public void setAipIngestDirectResourceUri(String aipIngestDirectResourceUri) {
+    this.aipIngestDirectResourceUri = aipIngestDirectResourceUri;
   }
 
   public Map<String, String> getDipResourceUriByAicName() {

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveLinkRelations.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveLinkRelations.java
@@ -27,6 +27,7 @@ public interface InfoArchiveLinkRelations extends StandardLinkRelations {
   String LINK_FILE_SYSTEM_ROOTS = LINK_PREFIX + "file-system-roots";
   String LINK_HOLDINGS = LINK_PREFIX + "holdings";
   String LINK_INGEST = LINK_PREFIX + "ingest";
+  String LINK_INGEST_DIRECT = LINK_PREFIX + "ingest-direct";
   String LINK_INGEST_NODES = LINK_PREFIX + "ingest-nodes";
   String LINK_INGESTS = LINK_INGEST + "s";
   String LINK_JOB_CONFIRMATION = "?spel=?[name=='Confirmation']";

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
@@ -43,10 +43,16 @@ public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRela
 
   @Override
   public String ingest(InputStream sip) throws IOException {
-    ReceptionResponse response = restClient.post(resourceCache.getAipResourceUri(), ReceptionResponse.class,
-        new TextPart("format", "sip_zip"), new BinaryPart("sip", sip, "IASIP.zip"));
-    return restClient.put(response.getUri(LINK_INGEST), IngestionResponse.class)
-      .getAipId();
+    final String ingestDirectUri = resourceCache.getAipIngestDirectResourceUri();
+    if (ingestDirectUri != null) {
+      return restClient.post(ingestDirectUri, IngestionResponse.class, new TextPart("format", "sip_zip"),
+          new BinaryPart("sip", sip, "IASIP.zip")).getAipId();
+    } else {
+      ReceptionResponse response = restClient.post(resourceCache.getAipResourceUri(), ReceptionResponse.class,
+          new TextPart("format", "sip_zip"), new BinaryPart("sip", sip, "IASIP.zip"));
+      return restClient.put(response.getUri(LINK_INGEST), IngestionResponse.class)
+          .getAipId();
+    }
   }
 
   @Override

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
@@ -44,14 +44,14 @@ public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRela
   @Override
   public String ingest(InputStream sip) throws IOException {
     final String ingestDirectUri = resourceCache.getAipIngestDirectResourceUri();
-    if (ingestDirectUri != null) {
-      return restClient.post(ingestDirectUri, IngestionResponse.class, new TextPart("format", "sip_zip"),
-          new BinaryPart("sip", sip, "IASIP.zip")).getAipId();
-    } else {
+    if (ingestDirectUri == null) {
       ReceptionResponse response = restClient.post(resourceCache.getAipResourceUri(), ReceptionResponse.class,
           new TextPart("format", "sip_zip"), new BinaryPart("sip", sip, "IASIP.zip"));
       return restClient.put(response.getUri(LINK_INGEST), IngestionResponse.class)
-          .getAipId();
+                 .getAipId();
+    } else {
+      return restClient.post(ingestDirectUri, IngestionResponse.class, new TextPart("format", "sip_zip"),
+          new BinaryPart("sip", sip, "IASIP.zip")).getAipId();
     }
   }
 

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -149,6 +149,7 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     Libraries libraries = mock(Libraries.class);
     Contents contents = new Contents();
     aics = mock(Aics.class);
+    LinkContainer aips = new LinkContainer();
     Queries queries = mock(Queries.class);
     Quotas quotas = mock(Quotas.class);
     ResultConfigurationHelpers helpers = mock(ResultConfigurationHelpers.class);
@@ -176,6 +177,8 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     when(link.getHref()).thenReturn(BILLBOARD_URI);
     mockCollection(ExportConfigurations.class, exportConfigurations);
     mockCollection(ExportPipelines.class, exportPipelines);
+    when(restClient.follow(application, InfoArchiveLinkRelations.LINK_AIPS, LinkContainer.class)).thenReturn(aips);
+    aips.setLinks(links);
 
     mockCollection(Applications.class, applications);
     mockCollection(Federations.class, federations);
@@ -345,6 +348,24 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     when(ingestionResponse.getAipId()).thenReturn("sip001");
 
     assertEquals(archiveClient.ingest(sip), "sip001");
+  }
+
+  @Test
+  public void shouldIngestWithIngestDirect() throws IOException {
+    Link link = new Link();
+    link.setHref(BILLBOARD_URI);
+    links.put(InfoArchiveLinkRelations.LINK_INGEST_DIRECT, link);
+    archiveClient = ArchiveClients.withPropertyBasedAutoConfiguration(configuration, restClient);
+
+    String source = "This is the source of my input stream";
+    InputStream sip = IOUtils.toInputStream(source, "UTF-8");
+
+    IngestionResponse ingestionResponse = mock(IngestionResponse.class);
+    when(restClient.post(anyString(), eq(IngestionResponse.class), any(Part.class), any(Part.class)))
+        .thenReturn(ingestionResponse);
+    when(ingestionResponse.getAipId()).thenReturn("sip002");
+
+    assertEquals(archiveClient.ingest(sip), "sip002");
   }
 
   @Test(expected = RuntimeException.class)


### PR DESCRIPTION
These changes allows client to use ingest-direct reference to ingest with only one request.
- Currently DSS with multiple AIPs are not supported (if ingest-direct is available, it will try to use it and will be rejected)
