### PR TITLE
IAIF-195: Add new functionality to SIP-SDK for fetching exported packages

### DIFF
--- a/core/src/main/java/com/emc/ia/sdk/sip/client/ArchiveClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/ArchiveClient.java
@@ -5,8 +5,11 @@ package com.emc.ia.sdk.sip.client;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 
+import com.emc.ia.sdk.sip.client.dto.OrderItem;
+import com.emc.ia.sdk.sip.client.dto.SearchComposition;
+import com.emc.ia.sdk.sip.client.dto.SearchResults;
+import com.emc.ia.sdk.sip.client.dto.export.ExportConfiguration;
 import com.emc.ia.sdk.sip.client.dto.query.SearchQuery;
 
 /**
@@ -42,13 +45,41 @@ public interface ArchiveClient {
   ContentResult fetchContent(String contentId) throws IOException;
 
   /**
-   * Fetch the exported package for the specified URI, file name and download token.
-   * @param baseUri The URI of the package to fetch.
-   * @param fileName The file name of the package.
-   * @param downloadToken The download token to fetch.
+   * Fetch the content for the specified order item.
+   * @param orderItem The order item.
    * @return A ContentResult
    * @throws IOException When an I/O error occurs
    */
-  ContentResult fetchExportedPackage(URI baseUri, String fileName, String downloadToken) throws IOException;
+  ContentResult fetchOrderContent(OrderItem orderItem) throws IOException;
+
+  /**
+   * Get the search results for the specified search query and composition.
+   * @param searchQuery The search query.
+   * @param searchComposition The search composition.
+   * @return A SearchResults
+   * @throws IOException When an I/O error occurs
+   */
+  SearchResults search(SearchQuery searchQuery, SearchComposition searchComposition) throws IOException;
+
+  /**
+   * Start the export of the search results for the specified export configuration.
+   * @param searchResults The search results.
+   * @param exportConfiguration The export configuration.
+   * @param outputName The output name of result package.
+   * @return An OrderItem object that contains information about exported package without link to download it
+   * @throws IOException When an I/O error occurs
+   */
+  OrderItem export(SearchResults searchResults, ExportConfiguration exportConfiguration, String outputName) throws IOException;
+
+  /**
+   * Start and wait the export of the search results for the specified export configuration.
+   * @param searchResults The search results.
+   * @param exportConfiguration The export configuration.
+   * @param outputName The output name of result package.
+   * @param timeOutInMillis The timeout of export process in milliseconds.
+   * @return An OrderItem object that contains information about exported package and link to download it
+   * @throws IOException When an I/O error occurs
+   */
+  OrderItem exportAndWait(SearchResults searchResults, ExportConfiguration exportConfiguration, String outputName, long timeOutInMillis) throws IOException;
 
 }

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/ArchiveClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/ArchiveClient.java
@@ -5,6 +5,7 @@ package com.emc.ia.sdk.sip.client;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 
 import com.emc.ia.sdk.sip.client.dto.query.SearchQuery;
 
@@ -39,5 +40,15 @@ public interface ArchiveClient {
    * @throws IOException When an I/O error occurs
    */
   ContentResult fetchContent(String contentId) throws IOException;
+
+  /**
+   * Fetch the exported package for the specified URI, file name and download token.
+   * @param baseUri The URI of the package to fetch.
+   * @param fileName The file name of the package.
+   * @param downloadToken The download token to fetch.
+   * @return A ContentResult
+   * @throws IOException When an I/O error occurs
+   */
+  ContentResult fetchExportedPackage(URI baseUri, String fileName, String downloadToken) throws IOException;
 
 }

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/OrderItem.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/OrderItem.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 EMC Corporation. All Rights Reserved.
+ */
+package com.emc.ia.sdk.sip.client.dto;
+
+public class OrderItem extends NamedLinkContainer {
+
+  private String type;
+
+  public OrderItem() {
+    setType("EXPORT");
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public final void setType(String type) {
+    this.type = type;
+  }
+
+}

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/OrderItems.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/OrderItems.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2016 EMC Corporation. All Rights Reserved.
+ */
+package com.emc.ia.sdk.sip.client.dto;
+
+public class OrderItems extends ItemContainer<OrderItem> {
+
+  protected OrderItems() {
+    super("orderItems");
+  }
+
+}

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/Row.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/Row.java
@@ -8,10 +8,19 @@ import java.util.List;
 
 public class Row {
 
+  private String id;
   private List<Column> columns;
 
   public Row() {
     setColumns(new ArrayList<Column>());
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public final void setId(String id) {
+    this.id = id;
   }
 
   public List<Column> getColumns() {

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/SearchDataBuilder.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/SearchDataBuilder.java
@@ -27,6 +27,16 @@ public final class SearchDataBuilder {
     return this;
   }
 
+  private SearchDataBuilder criterion(String field, String operator, String value1, String value2) {
+    builder.element("criterion")
+      .element("name", field)
+      .element("operator", operator)
+      .element("value", value1)
+      .element("value", value2)
+      .end();
+    return this;
+  }
+
   public SearchDataBuilder equal(String filed, String value) {
     return criterion(filed, "EQUAL", value);
   }
@@ -41,6 +51,10 @@ public final class SearchDataBuilder {
 
   public SearchDataBuilder endsWith(String filed, String value) {
     return criterion(filed, "ENDS_WITH", value);
+  }
+
+  public SearchDataBuilder between(String filed, String value1, String value2) {
+    return criterion(filed, "BETWEEN", value1, value2);
   }
 
   public SearchDataBuilder contains(String filed, String value) {

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/SearchResult.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/SearchResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016 EMC Corporation. All Rights Reserved.
+ */
+package com.emc.ia.sdk.sip.client.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchResult extends NamedLinkContainer {
+
+  private int totalElements;
+  private int executionTime;
+  private boolean empty;
+  private List<Row> rows;
+
+  public SearchResult() {
+    setRows(new ArrayList<Row>());
+  }
+
+  public int getTotalElements() {
+    return totalElements;
+  }
+
+  public final void setTotalElements(int totalElements) {
+    this.totalElements = totalElements;
+  }
+
+  public int getExecutionTime() {
+    return executionTime;
+  }
+
+  public final void setExecutionTime(int executionTime) {
+    this.executionTime = executionTime;
+  }
+
+  public List<Row> getRows() {
+    return rows;
+  }
+
+  public final void setRows(List<Row> rows) {
+    this.rows = rows;
+  }
+
+  public boolean isEmpty() {
+    return empty;
+  }
+
+  public void setEmpty(boolean empty) {
+    this.empty = empty;
+  }
+}

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/SearchResults.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/SearchResults.java
@@ -5,21 +5,42 @@ package com.emc.ia.sdk.sip.client.dto;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-public class SearchResults {
+import com.emc.ia.sdk.support.rest.LinkContainer;
 
-  private List<Row> rows;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-  public SearchResults() {
-    setRows(new ArrayList<Row>());
+public class SearchResults extends LinkContainer {
+
+  private static final String KEY = "results";
+  private final List<SearchResult> results = new ArrayList<>();
+
+  @JsonProperty("_embedded")
+  protected void setEmbedded(Map<String, List<SearchResult>> embedded) {
+    results.clear();
+    List<SearchResult> embeddedItems = embedded.get(KEY);
+    if (embeddedItems == null) {
+      throw new IllegalArgumentException(
+        String.format("Expected results under key '%s', but got keys %s", KEY, embedded.keySet()));
+    }
+    results.addAll(embeddedItems);
+  }
+
+  public List<SearchResult> getResults() {
+    return results;
+  }
+
+  public void addResult(SearchResult searchResult) {
+    results.add(searchResult);
   }
 
   public List<Row> getRows() {
+    List<Row> rows = new ArrayList<>();
+    for (SearchResult searchResult: results) {
+      rows.addAll(searchResult.getRows());
+    }
     return rows;
-  }
-
-  public final void setRows(List<Row> rows) {
-    this.rows = rows;
   }
 
 }

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveLinkRelations.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveLinkRelations.java
@@ -19,6 +19,7 @@ public interface InfoArchiveLinkRelations extends StandardLinkRelations {
   String LINK_DATABASES = LINK_PREFIX + "xdb-databases";
   String LINK_DIP = LINK_PREFIX + "dip";
   String LINK_DOWNLOAD = LINK_PREFIX + "content-download";
+  String LINK_EXPORT = LINK_PREFIX + "export";
   String LINK_EXPORT_CONFIG = LINK_PREFIX + "export-configurations";
   String LINK_EXPORT_PIPELINE = LINK_PREFIX + "export-pipelines";
   String LINK_EXPORT_TRANSFORMATION = LINK_PREFIX + "export-transformations";

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
@@ -76,4 +76,13 @@ public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRela
     }
   }
 
+  @Override
+  public ContentResult fetchExportedPackage(URI baseUri, String fileName, String downloadToken) throws IOException {
+    String queryUri = restClient.uri(baseUri.toString())
+      .addParameter("filename", fileName.replace(" ", "%20"))
+      .addParameter("downloadToken", downloadToken)
+      .build();
+    return restClient.get(queryUri, contentResultFactory);
+  }
+
 }

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.http.client.utils.URIBuilder;
@@ -16,13 +18,28 @@ import com.emc.ia.sdk.sip.client.ArchiveClient;
 import com.emc.ia.sdk.sip.client.ContentResult;
 import com.emc.ia.sdk.sip.client.QueryResult;
 import com.emc.ia.sdk.sip.client.dto.IngestionResponse;
+import com.emc.ia.sdk.sip.client.dto.OrderItem;
 import com.emc.ia.sdk.sip.client.dto.ReceptionResponse;
+import com.emc.ia.sdk.sip.client.dto.Row;
+import com.emc.ia.sdk.sip.client.dto.SearchComposition;
+import com.emc.ia.sdk.sip.client.dto.SearchDataBuilder;
+import com.emc.ia.sdk.sip.client.dto.SearchResult;
+import com.emc.ia.sdk.sip.client.dto.SearchResults;
+import com.emc.ia.sdk.sip.client.dto.export.ExportConfiguration;
+import com.emc.ia.sdk.sip.client.dto.query.Comparison;
+import com.emc.ia.sdk.sip.client.dto.query.Item;
 import com.emc.ia.sdk.sip.client.dto.query.QueryFormatter;
 import com.emc.ia.sdk.sip.client.dto.query.SearchQuery;
 import com.emc.ia.sdk.support.http.BinaryPart;
 import com.emc.ia.sdk.support.http.ResponseFactory;
 import com.emc.ia.sdk.support.http.TextPart;
 import com.emc.ia.sdk.support.rest.RestClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 /**
  * Implementation of {@linkplain ArchiveClient} that uses the REST API of a running InfoArchive server.
@@ -77,12 +94,105 @@ public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRela
   }
 
   @Override
-  public ContentResult fetchExportedPackage(URI baseUri, String fileName, String downloadToken) throws IOException {
-    String queryUri = restClient.uri(baseUri.toString())
-      .addParameter("filename", fileName.replace(" ", "%20"))
-      .addParameter("downloadToken", downloadToken)
+  public ContentResult fetchOrderContent(OrderItem orderItem) throws IOException {
+    String fetchUri = restClient.uri(orderItem.getUri(LINK_DOWNLOAD))
+      .addParameter("downloadToken", "")
       .build();
-    return restClient.get(queryUri, contentResultFactory);
+    return restClient.get(fetchUri, contentResultFactory);
+  }
+
+  @Override
+  public SearchResults search(SearchQuery searchQuery, SearchComposition searchComposition) throws IOException {
+    String searchResultBaseUri = searchComposition.getSelfUri();
+    String xmlSearchQuery = getXmlStringFromSearchQuery(searchQuery);
+    SearchResults totalSearchResults = restClient.postXml(searchResultBaseUri, xmlSearchQuery, SearchResults.class);
+    while (searchResultBaseUri != null) {
+      SearchResults onePageSearchResults = restClient.postXml(searchResultBaseUri, "", SearchResults.class);
+      for (SearchResult searchResult: onePageSearchResults.getResults()) {
+        totalSearchResults.addResult(searchResult);
+      }
+      searchResultBaseUri = onePageSearchResults.getUri("next");
+    }
+    return totalSearchResults;
+  }
+
+  private String getXmlStringFromSearchQuery(SearchQuery searchQuery) {
+    SearchDataBuilder searchDataBuilder = SearchDataBuilder.builder();
+    for (Item item: searchQuery.getItems()) {
+      if (item instanceof Comparison) {
+        Comparison comparison = (Comparison)item;
+        switch (comparison.getOperator()) {
+          case EQUAL: searchDataBuilder.equal(comparison.getName(), comparison.getValue().get(0));
+            break;
+          case NOT_EQUAL:
+            searchDataBuilder.notEqual(comparison.getName(), comparison.getValue().get(0));
+            break;
+          case STARTS_WITH:
+            searchDataBuilder.startsWith(comparison.getName(), comparison.getValue().get(0));
+            break;
+          case BETWEEN:
+            searchDataBuilder.between(comparison.getName(), comparison.getValue().get(0), comparison.getValue().get(1));
+            break;
+          default:
+            break;
+        }
+      }
+    }
+    return searchDataBuilder.build().replaceFirst("<\\?.*\\?>", "").replace(" ", "").replace("\n", "");
+  }
+
+  @Override
+  public OrderItem export(SearchResults searchResults, ExportConfiguration exportConfiguration, String outputName) throws IOException {
+    String fullOutputName = outputName + '_' + Long.toString(new Date().getTime());
+    String exportUri = restClient.uri(searchResults.getUri(LINK_EXPORT))
+      .addParameter("name", fullOutputName)
+      .build();
+    String exportRequestBody = getValidJsonRequestForExport(exportConfiguration.getSelfUri(), searchResults.getResults());
+    return restClient.post(exportUri, exportRequestBody, OrderItem.class);
+  }
+
+  @Override
+  public OrderItem exportAndWait(SearchResults searchResults, ExportConfiguration exportConfiguration, String outputName, long timeOutInMillis) throws IOException {
+    String fullOutputName = outputName + '_' + Long.toString(new Date().getTime());
+    String exportUri = restClient.uri(searchResults.getUri(LINK_EXPORT))
+      .addParameter("name", fullOutputName)
+      .build();
+    String exportRequestBody = getValidJsonRequestForExport(exportConfiguration.getSelfUri(), searchResults.getResults());
+    OrderItem plainOrderItem = restClient.post(exportUri, exportRequestBody, OrderItem.class);
+
+    long endTimeOfExport;
+    if (timeOutInMillis < 5000) {
+      endTimeOfExport = System.currentTimeMillis() + 5000;
+    } else {
+      endTimeOfExport = System.currentTimeMillis() + timeOutInMillis;
+    }
+    while (System.currentTimeMillis() < endTimeOfExport) {
+      OrderItem downloadOrderItem = restClient.get(plainOrderItem.getSelfUri(), OrderItem.class);
+      if (downloadOrderItem.getUri(LINK_DOWNLOAD) != null) {
+        return downloadOrderItem;
+      }
+      try {
+        Thread.sleep(3000);
+      } catch (InterruptedException e) {
+        // Ignored
+      }
+    }
+    return plainOrderItem;
+  }
+
+  private String getValidJsonRequestForExport(String exportConfigurationUri, List<SearchResult> searchResults) throws IOException {
+    JsonNodeFactory jsonNodeFactory = new ObjectMapper().getNodeFactory();
+    ObjectNode root = jsonNodeFactory.objectNode();
+    ArrayNode includedRows = jsonNodeFactory.arrayNode();
+    for (SearchResult searchResult: searchResults) {
+      for (Row row: searchResult.getRows()) {
+        includedRows.add(row.getId());
+      }
+    }
+    TextNode exportConfiguration = jsonNodeFactory.textNode(exportConfigurationUri);
+    root.set("exportConfiguration", exportConfiguration);
+    root.set("includedRows", includedRows);
+    return root.toString();
   }
 
 }

--- a/core/src/main/java/com/emc/ia/sdk/support/http/MediaTypes.java
+++ b/core/src/main/java/com/emc/ia/sdk/support/http/MediaTypes.java
@@ -7,6 +7,7 @@ public interface MediaTypes {
 
   String BINARY = "application/octect-stream";
   String HAL = "application/hal+json";
+  String XML = "application/xml";
   String TEXT = "text/plain";
 
 }

--- a/core/src/main/java/com/emc/ia/sdk/support/rest/RestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/support/rest/RestClient.java
@@ -59,7 +59,7 @@ public class RestClient implements Closeable, StandardLinkRelations {
   }
 
   public <T> T post(String uri, String data, Class<T> type) throws IOException {
-    return httpClient.post(uri, withContentType(MediaTypes.HAL), data, type);
+    return httpClient.post(uri, withContentType(MediaTypes.HAL), toJson(data), type);
   }
 
   public <T> T postXml(String uri, String data, Class<T> type) throws IOException {

--- a/core/src/main/java/com/emc/ia/sdk/support/rest/RestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/support/rest/RestClient.java
@@ -59,7 +59,11 @@ public class RestClient implements Closeable, StandardLinkRelations {
   }
 
   public <T> T post(String uri, String data, Class<T> type) throws IOException {
-    return httpClient.post(uri, withContentType(MediaTypes.HAL), toJson(data), type);
+    return httpClient.post(uri, withContentType(MediaTypes.HAL), data, type);
+  }
+
+  public <T> T postXml(String uri, String data, Class<T> type) throws IOException {
+    return httpClient.post(uri, withContentType(MediaTypes.XML), data, type);
   }
 
   public <T> T follow(LinkContainer state, String relation, Class<T> type) throws IOException {

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -64,9 +64,11 @@ import com.emc.ia.sdk.sip.client.dto.ResultConfigurationHelper;
 import com.emc.ia.sdk.sip.client.dto.ResultConfigurationHelpers;
 import com.emc.ia.sdk.sip.client.dto.RetentionPolicies;
 import com.emc.ia.sdk.sip.client.dto.RetentionPolicy;
+import com.emc.ia.sdk.sip.client.dto.Row;
 import com.emc.ia.sdk.sip.client.dto.Search;
 import com.emc.ia.sdk.sip.client.dto.SearchComposition;
 import com.emc.ia.sdk.sip.client.dto.SearchCompositions;
+import com.emc.ia.sdk.sip.client.dto.SearchResult;
 import com.emc.ia.sdk.sip.client.dto.SearchResults;
 import com.emc.ia.sdk.sip.client.dto.Searches;
 import com.emc.ia.sdk.sip.client.dto.Services;
@@ -490,6 +492,13 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     when(restClient.post(eq(uri), anyString(), eq(OrderItem.class))).thenReturn(orderItem);
 
     SearchResults searchResults = new SearchResults();
+    SearchResult searchResult = new SearchResult();
+    List<Row> rows = new ArrayList<>();
+    Row row = new Row();
+    row.setId(randomString());
+    rows.add(row);
+    searchResult.setRows(rows);
+    searchResults.addResult(searchResult);
     ExportConfiguration exportConfiguration = mock(ExportConfiguration.class);
     when(exportConfiguration.getSelfUri()).thenReturn(uri);
 

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -85,6 +87,8 @@ import com.emc.ia.sdk.sip.client.dto.query.Comparison;
 import com.emc.ia.sdk.sip.client.dto.query.Operator;
 import com.emc.ia.sdk.sip.client.dto.query.SearchQuery;
 import com.emc.ia.sdk.sip.client.dto.result.searchconfig.AllSearchComponents;
+import com.emc.ia.sdk.sip.client.rest.ContentResultFactory;
+import com.emc.ia.sdk.sip.client.rest.DefaultContentResult;
 import com.emc.ia.sdk.sip.client.rest.DefaultQueryResult;
 import com.emc.ia.sdk.sip.client.rest.InfoArchiveLinkRelations;
 import com.emc.ia.sdk.sip.client.rest.QueryResultFactory;
@@ -418,6 +422,30 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     QueryResult result = archiveClient.query(query, aicName, schema, 10);
 
     assertEquals(queryResult, result);
+  }
+
+  @Test
+  public void shouldFetchExportedPackageSuccessfully() throws IOException, URISyntaxException {
+    UriBuilder uriBuilder = mock(UriBuilder.class);
+
+    URI baseUri = new URI("http://localhost:8888/");
+    String fileName = randomString();
+    String downloadToken = randomString();
+
+    String uri = baseUri.toString();
+    when(uriBuilder.build()).thenReturn(uri);
+    when(uriBuilder.addParameter(anyString(), anyString())).thenReturn(uriBuilder);
+    when(restClient.uri(anyString())).thenReturn(uriBuilder);
+
+    ContentResultFactory contentResultFactory = mock(ContentResultFactory.class);
+    DefaultContentResult contentResult = mock(DefaultContentResult.class);
+    when(contentResultFactory.create(any(Response.class))).thenReturn(contentResult);
+    when(restClient.get(eq(uri), any(ContentResultFactory.class))).thenReturn(contentResult);
+
+    archiveClient = ArchiveClients.withPropertyBasedAutoConfiguration(configuration, restClient);
+    ContentResult result = archiveClient.fetchExportedPackage(baseUri, fileName, downloadToken);
+
+    assertEquals(contentResult, result);
   }
 
   @Test

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -438,13 +439,13 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     configuration.put(InfoArchiveConfiguration.FEDERATION_NAME, randomString());
     when(restClient.createCollectionItem(eq(federations), any(Federation.class), eq(LINK_ADD), eq(LINK_SELF)))
         .then(invocation -> {
-      throw new HttpException(503, "");
-    });
+          throw new HttpException(503, "");
+        });
 
     ArchiveClients.withPropertyBasedAutoConfiguration(configuration, restClient, mock(Clock.class));
 
     verify(restClient, times(5)).createCollectionItem(
-        eq(federations), any(Federation.class), eq(LINK_ADD), eq(LINK_SELF));
+                                                       eq(federations), any(Federation.class), eq(LINK_ADD), eq(LINK_SELF));
   }
 
   @Test

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -439,13 +439,13 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     configuration.put(InfoArchiveConfiguration.FEDERATION_NAME, randomString());
     when(restClient.createCollectionItem(eq(federations), any(Federation.class), eq(LINK_ADD), eq(LINK_SELF)))
         .then(invocation -> {
-          throw new HttpException(503, "");
-        });
+      throw new HttpException(503, "");
+    });
 
     ArchiveClients.withPropertyBasedAutoConfiguration(configuration, restClient, mock(Clock.class));
 
     verify(restClient, times(5)).createCollectionItem(
-                                                       eq(federations), any(Federation.class), eq(LINK_ADD), eq(LINK_SELF));
+        eq(federations), any(Federation.class), eq(LINK_ADD), eq(LINK_SELF));
   }
 
   @Test


### PR DESCRIPTION
These changes allows client to search data in IA, export search results and fetch exported orders.

Added 4 new functions:
1. `ContentResult fetchOrderContent(OrderItem orderItem)`
2. `SearchResults search(SearchQuery searchQuery, SearchComposition searchComposition)`
3. `OrderItem export(SearchResults searchResults, ExportConfiguration exportConfiguration, String outputName)`
4. `OrderItem exportAndWait(SearchResults searchResults, ExportConfiguration exportConfiguration, String outputName, long timeOutInMillis)`

For more information please look at javadoc of ArchiveClient.java
