### PR TITLE
IAIF-189: Holding configuration should set managedItemStore property

### DIFF
--- a/core/src/main/java/com/emc/ia/sdk/sip/client/dto/Holding.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/dto/Holding.java
@@ -27,6 +27,7 @@ public class Holding extends NamedLinkContainer { // NOPMD TooManyFields - Dicta
   private String xdbLibraryParent;
   private boolean pdiXmlHashEnforced;
   private String sipStore;
+  private String managedItemStore;
   private List<RetentionClass> retentionClasses;
   private List<PdiConfig> pdiConfigs;
 
@@ -197,6 +198,14 @@ public class Holding extends NamedLinkContainer { // NOPMD TooManyFields - Dicta
     this.sipStore = sipStore;
   }
 
+  public String getManagedItemStore() {
+    return managedItemStore;
+  }
+
+  public void setManagedItemStore(String managedItemStore) {
+    this.managedItemStore = managedItemStore;
+  }
+
   public List<RetentionClass> getRetentionClasses() {
     return retentionClasses;
   }
@@ -220,6 +229,7 @@ public class Holding extends NamedLinkContainer { // NOPMD TooManyFields - Dicta
     setSipStore(store);
     setXdbStore(store);
     setXmlStore(store);
+    setManagedItemStore(store);
   }
 
 }

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/dto/WhenTransferringHoldingData.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/dto/WhenTransferringHoldingData.java
@@ -18,11 +18,12 @@ public class WhenTransferringHoldingData extends TestCase {
 
     holding.setAllStores(store);
 
-    assertEquals("Ci", store, holding.getCiStore());
-    assertEquals("Ci", store, holding.getLogStore());
-    assertEquals("Ci", store, holding.getRenditionStore());
-    assertEquals("Ci", store, holding.getXdbStore());
-    assertEquals("Ci", store, holding.getXmlStore());
+    assertEquals("Ci Store", store, holding.getCiStore());
+    assertEquals("Log Store", store, holding.getLogStore());
+    assertEquals("Rendition Store", store, holding.getRenditionStore());
+    assertEquals("XDB Store", store, holding.getXdbStore());
+    assertEquals("XML Store", store, holding.getXmlStore());
+    assertEquals("Managed Item Store", store, holding.getManagedItemStore());
   }
 
 }


### PR DESCRIPTION
These changes provide support for managed items backup store introduced in 4.1. It adds the managedItemStore property to holding during installation. The managedItemStore is set like the other stores in holding.
