### PR TITLE
Remove usage of 'toJson' function in RestClient

### DIFF
--- a/core/src/main/java/com/emc/ia/sdk/support/rest/RestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/support/rest/RestClient.java
@@ -60,7 +60,7 @@ public class RestClient implements Closeable, StandardLinkRelations {
   }
 
   public <T> T post(String uri, String data, Class<T> type) throws IOException {
-    return httpClient.post(uri, withAuthorization(withContentType(MediaTypes.HAL)), toJson(data), type);
+    return httpClient.post(uri, withAuthorization(withContentType(MediaTypes.HAL)), data, type);
   }
 
   public <T> T postXml(String uri, String data, Class<T> type) throws IOException {


### PR DESCRIPTION
This function adds unnecessary slashes before quotes in JSON String.
Example code:
```
String input = "{\"name\": \"value\";}";
String output = toJson(input);
System.out.println(input);
System.out.println(output);
```
Console output:
```
{"name": "value";}
"{\"name\": \"value\";}"
```
It's the reason of the error in REST requests:
```
400 Bad Request
    {
      "_errors" : [ {
        "error" : "HttpMessage not readable.",
        "errorCodes" : [ ],
        "message" : "Problem reading the request body.",
        "localizedMessage" : "Problem reading the request body."
      } ],
      "_links" : { }
    })
```