### PR TITLE
JDepend package dependencies hotfix

### DIFF
--- a/core/src/main/java/com/emc/ia/sdk/configurer/ArchiveClients.java
+++ b/core/src/main/java/com/emc/ia/sdk/configurer/ArchiveClients.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016 EMC Corporation. All Rights Reserved.
  */
-package com.emc.ia.sdk.sip.client;
+package com.emc.ia.sdk.configurer;
 
 import static com.emc.ia.sdk.configurer.InfoArchiveConfiguration.*;
 
@@ -13,8 +13,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
-import com.emc.ia.sdk.configurer.AuthenticationStrategyFactory;
-import com.emc.ia.sdk.configurer.InfoArchiveConfigurers;
+import com.emc.ia.sdk.sip.client.ArchiveClient;
+import com.emc.ia.sdk.sip.client.ClientConfigurationFinder;
 import com.emc.ia.sdk.sip.client.dto.Aics;
 import com.emc.ia.sdk.sip.client.dto.Application;
 import com.emc.ia.sdk.sip.client.dto.Applications;

--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 
 import org.apache.http.client.utils.URIBuilder;
 
-import com.emc.ia.sdk.configurer.InfoArchiveConfiguration;
 import com.emc.ia.sdk.sip.client.ArchiveClient;
 import com.emc.ia.sdk.sip.client.ContentResult;
 import com.emc.ia.sdk.sip.client.QueryResult;
@@ -45,7 +44,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 /**
  * Implementation of {@linkplain ArchiveClient} that uses the REST API of a running InfoArchive server.
  */
-public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRelations, InfoArchiveConfiguration {
+public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRelations {
 
   private final ResponseFactory<DefaultQueryResult> queryResultFactory = new QueryResultFactory();
   private final ResponseFactory<ContentResult> contentResultFactory = new ContentResultFactory();

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.stubbing.OngoingStubbing;
 
+import com.emc.ia.sdk.configurer.ArchiveClients;
 import com.emc.ia.sdk.configurer.InfoArchiveConfiguration;
 import com.emc.ia.sdk.sip.client.dto.Aic;
 import com.emc.ia.sdk.sip.client.dto.Aics;

--- a/jdepend.gradle
+++ b/jdepend.gradle
@@ -32,7 +32,7 @@ task jdepend {
         }
       }
       logger.quiet 'Found cyclic dependencies between packages'
-      //throw new GradleException('Found cyclic dependencies between packages')
+      throw new GradleException('Found cyclic dependencies between packages')
     }
   }
 }


### PR DESCRIPTION
The changes fix packages cyclic dependencies but it can potantially break the existing code that depends on the `ArchiveClients` class because it was moved to another package).