### PR TITLE
Update SDK for change in IA REST API

### DIFF
--- a/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
+++ b/core/src/main/java/com/emc/ia/sdk/sip/client/rest/InfoArchiveRestClient.java
@@ -64,7 +64,7 @@ public class InfoArchiveRestClient implements ArchiveClient, InfoArchiveLinkRela
   public String ingest(InputStream sip) throws IOException {
     ReceptionResponse response = restClient.post(resourceCache.getAipResourceUri(), ReceptionResponse.class,
         new TextPart("format", "sip_zip"), new BinaryPart("sip", sip, "IASIP.zip"));
-    return restClient.put(response.getUri(LINK_INGEST), IngestionResponse.class).getAipId();
+    return restClient.post(response.getUri(LINK_INGEST), IngestionResponse.class).getAipId();
   }
 
   @Override

--- a/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/emc/ia/sdk/sip/client/WhenUsingInfoArchive.java
@@ -396,7 +396,7 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     receptionResponse.setLinks(links);
     when(restClient.post(anyString(), eq(ReceptionResponse.class), any(Part.class), any(Part.class)))
       .thenReturn(receptionResponse);
-    when(restClient.put(anyString(), eq(IngestionResponse.class))).thenReturn(ingestionResponse);
+    when(restClient.post(anyString(), eq(IngestionResponse.class))).thenReturn(ingestionResponse);
     when(ingestionResponse.getAipId()).thenReturn("sip001");
 
     assertEquals(archiveClient.ingest(sip), "sip001");
@@ -428,7 +428,7 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     IngestionResponse ingestionResponse = mock(IngestionResponse.class);
     when(restClient.post(anyString(), eq(ReceptionResponse.class), any(Part.class), any(Part.class)))
       .thenReturn(new ReceptionResponse());
-    when(restClient.put(anyString(), eq(IngestionResponse.class))).thenReturn(ingestionResponse);
+    when(restClient.post(anyString(), eq(IngestionResponse.class))).thenReturn(ingestionResponse);
     when(ingestionResponse.getAipId()).thenReturn("sip003");
 
     assertEquals(archiveClient.ingestDirect(sip), "sip003");


### PR DESCRIPTION
The REST API for AIPs has "changed". The old and new APIs exist side-by-side for now, but the old one will be removed in the future, most likely in 4.4.