### PR TITLE
Support proxies

### DIFF
--- a/core/src/main/java/com/opentext/ia/sdk/client/api/ArchiveConnection.java
+++ b/core/src/main/java/com/opentext/ia/sdk/client/api/ArchiveConnection.java
@@ -5,6 +5,8 @@ package com.opentext.ia.sdk.client.api;
 
 import java.util.Optional;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.opentext.ia.sdk.support.NewInstance;
 import com.opentext.ia.sdk.support.datetime.Clock;
 import com.opentext.ia.sdk.support.datetime.DefaultClock;
@@ -121,8 +123,13 @@ public class ArchiveConnection {
 
   public RestClient getRestClient() {
     if (restClient == null) {
-      HttpClient httpClient = NewInstance.of(getHttpClientClassName(), ApacheHttpClient.class.getName())
-          .as(HttpClient.class);
+      HttpClient httpClient;
+      if (StringUtils.isBlank(proxyHost) && StringUtils.isBlank(proxyPort)) {
+        httpClient = NewInstance.of(getHttpClientClassName(), ApacheHttpClient.class.getName())
+            .as(HttpClient.class);
+      } else {
+        httpClient = new ApacheHttpClient(proxyHost, Integer.parseInt(proxyPort));
+      }
       restClient = new RestClient(httpClient);
       AuthenticationStrategy authentication = new AuthenticationStrategyFactory(this).getAuthenticationStrategy(
           () -> httpClient, () -> clock);

--- a/core/src/main/java/com/opentext/ia/sdk/support/http/apache/ApacheHttpClient.java
+++ b/core/src/main/java/com/opentext/ia/sdk/support/http/apache/ApacheHttpClient.java
@@ -11,9 +11,11 @@ import java.util.Objects;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
@@ -54,12 +56,31 @@ public class ApacheHttpClient implements HttpClient {
     this(MAX_HTTP_CONNECTIONS, DEFAULT_CONNECTIONS_PER_ROUTE);
   }
 
+  public ApacheHttpClient(String proxyHost, int proxyPort) {
+    this(MAX_HTTP_CONNECTIONS, DEFAULT_CONNECTIONS_PER_ROUTE, proxyHost, proxyPort);
+  }
+
   public ApacheHttpClient(int maxHttpConnections, int maxConnectionsPerRoute) {
     PoolingHttpClientConnectionManager manager = new PoolingHttpClientConnectionManager();
     manager.setMaxTotal(maxHttpConnections);
     manager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
     client = HttpClients.custom()
       .setConnectionManager(manager)
+      .build();
+    mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+
+  public ApacheHttpClient(int maxHttpConnections, int maxConnectionsPerRoute, String proxyHost, int proxyPort) {
+    PoolingHttpClientConnectionManager manager = new PoolingHttpClientConnectionManager();
+    manager.setMaxTotal(maxHttpConnections);
+    manager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
+    RequestConfig defaultRequestConfig = RequestConfig.custom()
+      .setProxy(new HttpHost(proxyHost, proxyPort))
+      .build();
+    client = HttpClients.custom()
+      .setConnectionManager(manager)
+      .setDefaultRequestConfig(defaultRequestConfig)
       .build();
     mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/core/src/test/java/com/opentext/ia/sdk/dto/WhenUsingInfoArchive.java
+++ b/core/src/test/java/com/opentext/ia/sdk/dto/WhenUsingInfoArchive.java
@@ -238,6 +238,9 @@ public class WhenUsingInfoArchive extends TestCase implements InfoArchiveLinkRel
     configuration.put(InfoArchiveConfigurationProperties.SEARCH_DEFAULT_RESULT_MASTER, "");
     configuration.put(InfoArchiveConfigurationProperties.SEARCH_DEFAULT_SEARCH, "");
 
+    configuration.put(InfoArchiveConfigurationProperties.PROXY_HOST, "localhost");
+    configuration.put(InfoArchiveConfigurationProperties.PROXY_PORT, "8080");
+
     configuration.put("ia.aic.name", "MyAic");
     configuration.put("ia.aic.criteria.name", "name");
     configuration.put("ia.aic.criteria.label", "name");


### PR DESCRIPTION
Now if the configuration contains the properties `proxy.host` and `proxy.port`, we can configure the ApacheHttpClient to use a proxy.