### PR TITLE
Added synchronized for thread-safe especially when creating new sip

### DIFF
--- a/core/src/main/java/com/opentext/ia/sdk/sip/BatchSipAssembler.java
+++ b/core/src/main/java/com/opentext/ia/sdk/sip/BatchSipAssembler.java
@@ -76,7 +76,7 @@ public class BatchSipAssembler<D> {
    * @param domainObject The domain object to add
    * @throws IOException When an I/O error occurs
    */
-  public void add(D domainObject) throws IOException {
+  public synchronized void add(D domainObject) throws IOException {
     if (shouldStartNewSip(domainObject)) {
       startSip();
     }
@@ -117,7 +117,7 @@ public class BatchSipAssembler<D> {
    * End the batch assembly process.
    * @throws IOException When an I/O error occurs
    */
-  public void end() throws IOException {
+  public synchronized void end() throws IOException {
     setFinalSipInDss(true);
     closeCurrentSip();
   }


### PR DESCRIPTION
files in one thread and adding new data. Preventing duplicate root xml
nodes. Beware of line feed