### PR TITLE
Max Sip Size

### DIFF
--- a/core/src/main/java/com/opentext/ia/sdk/sip/BatchSipAssembler.java
+++ b/core/src/main/java/com/opentext/ia/sdk/sip/BatchSipAssembler.java
@@ -85,7 +85,8 @@ public class BatchSipAssembler<D> {
   }
 
   private boolean shouldStartNewSip(D component) {
-    return current == null || segmentationStrategy.shouldStartNewSip(component, assembler.getMetrics());
+    // We need to check that the DomainObject will fit in the Sip before we return anything
+    return segmentationStrategy.shouldStartNewSip(component, assembler.getMetrics()) || current == null;
   }
 
   private void startSip() throws IOException {

--- a/core/src/main/java/com/opentext/ia/sdk/sip/SipSegmentationStrategy.java
+++ b/core/src/main/java/com/opentext/ia/sdk/sip/SipSegmentationStrategy.java
@@ -94,9 +94,9 @@ public interface SipSegmentationStrategy<D> {
 
   /**
    * Return the size of a domain object in bytes.
+   * @param maxSize this is the maximum allowed size for the SIP
    * @param iterator used to iterate over the digital objects contained in the domain object
    * @return the size of the domain object in bytes
-   * @throws IOException This is thrown if the DomainObject is larger than the maximum allowed SIP size
    */
   static long getDomainObjectSize(Iterator<? extends DigitalObject> iterator, long maxSize) {
     long size = 0;

--- a/core/src/main/java/com/opentext/ia/sdk/sip/SipSegmentationStrategy.java
+++ b/core/src/main/java/com/opentext/ia/sdk/sip/SipSegmentationStrategy.java
@@ -99,7 +99,6 @@ public interface SipSegmentationStrategy<D> {
    * @throws IOException This is thrown if the DomainObject is larger than the maximum allowed SIP size
    */
   static long getDomainObjectSize(Iterator<? extends DigitalObject> iterator, long maxSize) {
-    // TODO if we're not adding the content we shouldn't unpack it
     long size = 0;
     while (iterator.hasNext()) {
       DigitalObject digitalObject = iterator.next();

--- a/core/src/main/java/com/opentext/ia/sdk/sip/SipSegmentationStrategy.java
+++ b/core/src/main/java/com/opentext/ia/sdk/sip/SipSegmentationStrategy.java
@@ -78,7 +78,7 @@ public interface SipSegmentationStrategy<D> {
 
   /**
    * Return a {@linkplain SipSegmentationStrategy} that allows a maximum total size (uncompressed) of the SIP including
-   * the object being added.
+   * the object being added, but NOT including the PDI.
    * @param <D> The type of domain objects to segment into different SIPs
    * @param maxSize The maximum size of the SIP
    * @param digitalObjectsExtraction The extractor for the type of digital object being added.

--- a/core/src/main/java/com/opentext/ia/sdk/support/io/DomainObjectTooBigException.java
+++ b/core/src/main/java/com/opentext/ia/sdk/support/io/DomainObjectTooBigException.java
@@ -4,7 +4,7 @@
 package com.opentext.ia.sdk.support.io;
 
 /**
- * Extends {@linkplain RuntimeException}. Used when a DomainObject is too big to fit in a SIP with the defined limit.
+ * Used when a DomainObject is too big to fit in a SIP with the defined limit.
  */
 public class DomainObjectTooBigException extends RuntimeException {
 
@@ -13,14 +13,14 @@ public class DomainObjectTooBigException extends RuntimeException {
   private final long domainObjectSize;
   private final long maxSipSize;
 
-  public DomainObjectTooBigException(long inDomainObjectSize, long inMaxSipSize) {
-    domainObjectSize = inDomainObjectSize;
-    maxSipSize = inMaxSipSize;
+  public DomainObjectTooBigException(long domainObjectSize, long maxSipSize) {
+    this.domainObjectSize = domainObjectSize;
+    this.maxSipSize = maxSipSize;
   }
 
   @Override
   public String getMessage() {
-    return "DomainObject is " + domainObjectSize + " bytes, but SegmentationStrategy MaxSize is set to " + maxSipSize
+    return "DomainObject is " + domainObjectSize + " bytes, but MaxSize is set to " + maxSipSize
         + " bytes.";
   }
 }

--- a/core/src/main/java/com/opentext/ia/sdk/support/io/DomainObjectTooBigException.java
+++ b/core/src/main/java/com/opentext/ia/sdk/support/io/DomainObjectTooBigException.java
@@ -3,10 +3,8 @@
  */
 package com.opentext.ia.sdk.support.io;
 
-import java.io.IOException;
-
 /**
- * Unchecked version of {@linkplain IOException}.
+ * Extends {@linkplain RuntimeException}. Used when a DomainObject is too big to fit in a SIP with the defined limit.
  */
 public class DomainObjectTooBigException extends RuntimeException {
 

--- a/core/src/main/java/com/opentext/ia/sdk/support/io/DomainObjectTooBigException.java
+++ b/core/src/main/java/com/opentext/ia/sdk/support/io/DomainObjectTooBigException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2017 by OpenText Corporation. All Rights Reserved.
+ */
+package com.opentext.ia.sdk.support.io;
+
+import java.io.IOException;
+
+/**
+ * Unchecked version of {@linkplain IOException}.
+ */
+public class DomainObjectTooBigException extends RuntimeException {
+
+  private static final long serialVersionUID = -3456477572689104546L;
+
+  private final long domainObjectSize;
+  private final long maxSipSize;
+
+  public DomainObjectTooBigException(long inDomainObjectSize, long inMaxSipSize) {
+    domainObjectSize = inDomainObjectSize;
+    maxSipSize = inMaxSipSize;
+  }
+
+  @Override
+  public String getMessage() {
+    return "DomainObject is " + domainObjectSize + " bytes, but SegmentationStrategy MaxSize is set to " + maxSipSize
+        + " bytes.";
+  }
+}

--- a/core/src/test/java/com/opentext/ia/sdk/sip/WhenAssemblingSipsInBatches.java
+++ b/core/src/test/java/com/opentext/ia/sdk/sip/WhenAssemblingSipsInBatches.java
@@ -135,7 +135,7 @@ public class WhenAssemblingSipsInBatches extends TestCase {
             digiObjs
                 .add(DigitalObject.fromBytes(randomString(), testDomainObject.substring(i, i + 1).getBytes("UTF-8")));
           } catch (UnsupportedEncodingException e) {
-            assertTrue("UnsupportedEncodingException in shouldRejectDomainObjectThatIsTooBig", false);
+            fail("UnsupportedEncodingException in shouldRejectDomainObjectThatIsTooBig");
           }
         }
         return digiObjs.iterator();

--- a/core/src/test/java/com/opentext/ia/sdk/sip/WhenSegmentingDomainObjectsIntoSips.java
+++ b/core/src/test/java/com/opentext/ia/sdk/sip/WhenSegmentingDomainObjectsIntoSips.java
@@ -5,12 +5,19 @@ package com.opentext.ia.sdk.sip;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import com.opentext.ia.sdk.support.io.DomainObjectTooBigException;
 import com.opentext.ia.test.TestCase;
 
 
@@ -18,6 +25,9 @@ public class WhenSegmentingDomainObjectsIntoSips extends TestCase {
 
   private SipSegmentationStrategy<String> strategy;
   private int expected;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void init() {
@@ -79,6 +89,103 @@ public class WhenSegmentingDomainObjectsIntoSips extends TestCase {
   @Test
   public void shouldSegmentBySipSize() {
     assertMaxSizePerSip(SipMetrics.SIZE_SIP, max -> SipSegmentationStrategy.byMaxSipSize(max));
+  }
+
+  @Test
+  public void shouldSegmentByProspectiveSipSize() throws IOException {
+    int noSips;
+    // Random Strings
+    noSips = executeSegmentByProspectiveSipSize(randomInt(50, 150), randomArrayOfStrings(randomInt(4, 8)));
+    assertEquals("SIP counts - Random generated Strings", expected, noSips);
+
+    // Boundary Test - 45 size and 90 limit
+    noSips = executeSegmentByProspectiveSipSize(90,
+        new String[] { "Hello", "Doman", "yuiopqwertyuiop", "poiuytrewqpoiuytrewq" });
+    assertEquals("SIP counts - Fixed Length Strings", expected, noSips);
+
+    // Boundary Test - 1 sip per AIU
+    noSips = executeSegmentByProspectiveSipSize(45,
+        new String[] { "Hello", "Doman", "yuiopqwertyuiop", "poiuytrewqpoiuytrewq" });
+    assertEquals("SIP counts - Fixed Length Strings", expected, noSips);
+  }
+
+  @Test
+  public void shouldThrowDomainObjectTooBigException() throws IOException {
+    thrown.expect(DomainObjectTooBigException.class);
+    executeSegmentByProspectiveSipSize(44,
+        new String[] { "Hello", "Doman", "yuiopqwertyuiop", "poiuytrewqpoiuytrewq" });
+  }
+
+  private int executeSegmentByProspectiveSipSize(int sipSizeLimit, String[] stringArray) throws IOException {
+    // Domain Object to test with
+    class TestDomainObject {
+
+      private String[] containedStrings;
+
+      TestDomainObject(String[] inContainedStrings) {
+        containedStrings = inContainedStrings;
+      }
+    }
+
+    // DigitalObjectsExtraction needs to be created and given to the segmentation strategy
+    class TestDomainObjectToDigitalObjects implements DigitalObjectsExtraction<TestDomainObject> {
+
+      @Override
+      public Iterator<? extends DigitalObject> apply(TestDomainObject testDomainObject) {
+        final ArrayList<DigitalObject> digiObjs = new ArrayList<>();
+        ArrayList<String> myStrings = new ArrayList<>(Arrays.asList(testDomainObject.containedStrings));
+        myStrings.forEach(eachWord -> digiObjs.add(DigitalObject.fromBytes(randomString(), eachWord.getBytes())));
+        return digiObjs.iterator();
+      }
+    }
+
+    int domainObjectSize = 0;
+    for (String thisOne : stringArray) {
+      domainObjectSize += thisOne.length();
+    }
+    Counters metrics = new Counters();
+
+    SipSegmentationStrategy<TestDomainObject> localStrategy =
+        SipSegmentationStrategy.byMaxProspectiveSipSize(sipSizeLimit, new TestDomainObjectToDigitalObjects());
+
+    // Variables to help determine what to expect from the test
+    int noDomainObjects = randomInt(6, 10);
+    int sipSizeSoFar = 0;
+    int expectedNumberOfSIPs = 1;
+    int actualNumberOfSIPs = 1;
+
+    for (int i = 0; i < noDomainObjects; i++) {
+      sipSizeSoFar += domainObjectSize;
+      metrics.inc(SipMetrics.SIZE_SIP, domainObjectSize);
+
+      TestDomainObject testDomainObject = new TestDomainObject(stringArray);
+      // Here we test the MaxProspectiveSipSize SegmentationStrategy
+      if (localStrategy.shouldStartNewSip(testDomainObject, new SipMetrics(metrics))) {
+        actualNumberOfSIPs++;
+        metrics.set(SipMetrics.SIZE_SIP, 0);
+      }
+      if (sipSizeSoFar + domainObjectSize > sipSizeLimit) {
+        expectedNumberOfSIPs++;
+        sipSizeSoFar = 0;
+      }
+    }
+    // If the SIP size is 0 after the last SIP is started, then the last SIP is empty so we take it off the total
+    if (sipSizeSoFar == 0) {
+      expectedNumberOfSIPs--;
+    }
+    if (metrics.get(SipMetrics.SIZE_SIP) == 0) {
+      actualNumberOfSIPs--;
+    }
+    expected = expectedNumberOfSIPs;
+    return actualNumberOfSIPs;
+  }
+
+  private String[] randomArrayOfStrings(int numberOfStrings) {
+    String[] arrayOfStrings = new String[numberOfStrings];
+    for (int i = 0; i < numberOfStrings; i++) {
+      arrayOfStrings[i] = randomString(randomInt(5, 20));
+    }
+    return arrayOfStrings;
   }
 
   @Test

--- a/core/src/test/java/com/opentext/ia/sdk/sip/WhenSegmentingDomainObjectsIntoSips.java
+++ b/core/src/test/java/com/opentext/ia/sdk/sip/WhenSegmentingDomainObjectsIntoSips.java
@@ -110,15 +110,15 @@ public class WhenSegmentingDomainObjectsIntoSips extends TestCase {
   }
 
   @Test
-  public void shouldSegmentByMaxProspectiveSipSize() throws IOException {
-    int noSips;
-    // Boundary Test - 45 size and 90 limit
-    noSips = executeSegmentByProspectiveSipSize(90,
+  public void shouldSegmentByMaxProspectiveSipSizeHalfMax() throws IOException {
+    int noSips = executeSegmentByProspectiveSipSize(90,
         new String[] { "Hello", "Doman", "yuiopqwertyuiop", "poiuytrewqpoiuytrewq" });
     assertEquals("SIP counts - Fixed Length Strings", expected, noSips);
+  }
 
-    // Boundary Test - exact match
-    noSips = executeSegmentByProspectiveSipSize(45,
+  @Test
+  public void shouldSegmentByMaxProspectiveSipSizeExact() throws IOException {
+    int noSips = executeSegmentByProspectiveSipSize(45,
         new String[] { "Hello", "Doman", "yuiopqwertyuiop", "poiuytrewqpoiuytrewq" });
     assertEquals("SIP counts - Fixed Length Strings", expected, noSips);
   }


### PR DESCRIPTION
This allows users to check what the size of a SIP WILL be before committing to adding another DomainObject.