### PR TITLE
Fix for the issue related to unnecessary conversion from String to Integer in YAML

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on http://keepachangelog.com/en/1.0.0/[Keep a Changelog] and this project follows the rules of 
 http://semver.org/spec/v2.0.0.html[Semantic Versioning].
 
+== 11.2.5 - 2018-08-27
+
+=== Fixed
+
+- Unnecessary conversion from String to Integer in YAML
+
+
+
 == 11.2.4 - TBD
 
 === Fixed

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ All jars can be found in the https://repo1.maven.org/maven2/com/opentext/ia/[Cen
 [source,groovy]
 ----
 dependencies { 
-  compile 'com.opentext.ia:infoarchive-sdk-core:11.2.4'
+  compile 'com.opentext.ia:infoarchive-sdk-core:11.2.5'
 }
 ----
 
@@ -46,7 +46,7 @@ dependencies {
   <dependency>
     <groupId>com.opentext.ia</groupId>
     <artifactId>infoarchive-sdk-core</artifactId>
-    <version>11.2.4</version>
+    <version>11.2.5</version>
   </dependency>
 </dependencies>
 ----

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ mavenRepo=https://repo1.maven.org/maven2
 org.gradle.jvmargs = -Xmx2048M
 
 group = com.opentext.ia
-version = 11.2.4
+version = 11.2.5
 
 systemProp.sonar.host.url = https://sonarcloud.io
 systemProp.sonar.organization = remonsinnema-github

--- a/yaml/src/main/java/com/opentext/ia/yaml/core/YamlMap.java
+++ b/yaml/src/main/java/com/opentext/ia/yaml/core/YamlMap.java
@@ -457,7 +457,7 @@ public class YamlMap {
   }
 
   private boolean needsToBeSingleQuoted(String text) {
-    return text.isEmpty() || text.matches("([\"%@*,].*)|(.*#.*)|(.*:\\s.*)");
+    return text.isEmpty() || text.matches("([\"%@*,].*)|(.*#.*)|(.*:\\s.*)|(^0\\d*$)");
   }
 
   private void appendSingleQuoted(String text, StringBuilder builder) {

--- a/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
+++ b/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
@@ -39,7 +39,6 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
   private static final String EMPTY = "Empty";
   private static final String NAME = "name";
   private static final String NAME_WITH_SEMICOLON = NAME + ": ";
-  private static final String LINE_BREAK = "\r\n";
   private static final String SAMPLE_YAML_STRING = String.format(
       "root:%n- property: value%n  sequence:%n  - one%n  - two%n  nested:%n    foo: bar%n  key: 'value: with: colons'%n");
 
@@ -558,7 +557,7 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
   }
 
   private void assertIntegerFieldValue(String expected, String actual) {
-    assertEquals(NAME_WITH_SEMICOLON + expected + LINE_BREAK, new YamlMap().put(NAME, actual).toString());
+    assertEquals(NAME_WITH_SEMICOLON + expected, new YamlMap().put(NAME, actual).toString().trim());
   }
 
 }

--- a/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
+++ b/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
@@ -38,7 +38,7 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
   private static final String TYPE = "type";
   private static final String EMPTY = "Empty";
   private static final String NAME = "name";
-  private static final String NAME_WITH_SEMICOLON = NAME + ": ";
+  private static final String SEMICOLON = ": ";
   private static final String SAMPLE_YAML_STRING = String.format(
       "root:%n- property: value%n  sequence:%n  - one%n  - two%n  nested:%n    foo: bar%n  key: 'value: with: colons'%n");
 
@@ -543,21 +543,40 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
 
   private void assertStringField(String fieldName, String fieldValue) {
     assertEquals(fieldValue, String.class,
-        YamlMap.from(fieldName + ": " + fieldValue).getRawData().get(fieldName).getClass());
+        YamlMap.from(fieldName + SEMICOLON + fieldValue).getRawData().get(fieldName).getClass());
   }
 
   @Test
-  public void shouldAddQuotesAroundIntegerFieldStartedWithZero() {
-    assertIntegerFieldValue("'0000'", "0000");
-    assertIntegerFieldValue("'01234'", "01234");
-    assertIntegerFieldValue("1234", "1234");
-    assertIntegerFieldValue("0123s", "0123s");
-    assertIntegerFieldValue("1234 1234 000", "1234 1234 000");
-    assertIntegerFieldValue("0 0 0 0", "0 0 0 0");
+  public void shouldGetProperFieldTypeAfterDeserialization() {
+    assertFieldTypeAfterDeserialization(String.class, "0000");
+    assertFieldTypeAfterDeserialization(String.class, "01234");
+    assertFieldTypeAfterDeserialization(String.class, "0123s");
+    assertFieldTypeAfterDeserialization(String.class, "1234 1234 000");
+    assertFieldTypeAfterDeserialization(String.class, "0 0 0 0");
+    assertFieldTypeAfterDeserialization(Integer.class, "1234");
   }
 
-  private void assertIntegerFieldValue(String expected, String actual) {
-    assertEquals(NAME_WITH_SEMICOLON + expected, new YamlMap().put(NAME, actual).toString().trim());
+  private void assertFieldTypeAfterDeserialization(Class fieldType, String fieldValue) {
+    String serializedYaml = new YamlMap().put(NAME, fieldValue).toString();
+    assertEquals(fieldValue, fieldType, YamlMap.from(serializedYaml).getRawData().get(NAME).getClass());
+  }
+
+  @Test
+  public void shouldAddQuotesToFieldStartingWithZeroAndConsistingOfDigits() {
+    assertEquals(expectedYamlNameValue("'0000'"), actualYamlNameValue("0000"));
+    assertEquals(expectedYamlNameValue("'01234'"), actualYamlNameValue("01234"));
+    assertEquals(expectedYamlNameValue("1234"), actualYamlNameValue("1234"));
+    assertEquals(expectedYamlNameValue("0123s"), actualYamlNameValue("0123s"));
+    assertEquals(expectedYamlNameValue("1234 1234 000"), actualYamlNameValue("1234 1234 000"));
+    assertEquals(expectedYamlNameValue("0 0 0 0"), actualYamlNameValue("0 0 0 0"));
+  }
+
+  private String expectedYamlNameValue(String fieldValue) {
+    return NAME + SEMICOLON + fieldValue;
+  }
+
+  private String actualYamlNameValue(String fieldValue) {
+    return new YamlMap().put(NAME, fieldValue).toString().trim();
   }
 
 }

--- a/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
+++ b/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
@@ -556,7 +556,7 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
     assertFieldTypeAfterDeserialization(Integer.class, "1234");
   }
 
-  private void assertFieldTypeAfterDeserialization(Class fieldType, String fieldValue) {
+  private void assertFieldTypeAfterDeserialization(Class<?> fieldType, String fieldValue) {
     String serializedYaml = new YamlMap().put(NAME, fieldValue).toString();
     assertEquals(fieldValue, fieldType, YamlMap.from(serializedYaml).getRawData().get(NAME).getClass());
   }

--- a/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
+++ b/yaml/src/test/java/com/opentext/ia/yaml/core/WhenWorkingWithYamlInAGenericYetTypeSafeManner.java
@@ -38,6 +38,8 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
   private static final String TYPE = "type";
   private static final String EMPTY = "Empty";
   private static final String NAME = "name";
+  private static final String NAME_WITH_SEMICOLON = NAME + ": ";
+  private static final String LINE_BREAK = "\r\n";
   private static final String SAMPLE_YAML_STRING = String.format(
       "root:%n- property: value%n  sequence:%n  - one%n  - two%n  nested:%n    foo: bar%n  key: 'value: with: colons'%n");
 
@@ -543,6 +545,20 @@ public class WhenWorkingWithYamlInAGenericYetTypeSafeManner extends TestCase {
   private void assertStringField(String fieldName, String fieldValue) {
     assertEquals(fieldValue, String.class,
         YamlMap.from(fieldName + ": " + fieldValue).getRawData().get(fieldName).getClass());
+  }
+
+  @Test
+  public void shouldAddQuotesAroundIntegerFieldStartedWithZero() {
+    assertIntegerFieldValue("'0000'", "0000");
+    assertIntegerFieldValue("'01234'", "01234");
+    assertIntegerFieldValue("1234", "1234");
+    assertIntegerFieldValue("0123s", "0123s");
+    assertIntegerFieldValue("1234 1234 000", "1234 1234 000");
+    assertIntegerFieldValue("0 0 0 0", "0 0 0 0");
+  }
+
+  private void assertIntegerFieldValue(String expected, String actual) {
+    assertEquals(NAME_WITH_SEMICOLON + expected + LINE_BREAK, new YamlMap().put(NAME, actual).toString());
   }
 
 }


### PR DESCRIPTION
Single quotes are added around names which begin with 0 and consist only of digits.