### PR TITLE
Added support for setting OAuth scopes

### DIFF
--- a/core/src/main/java/com/opentext/ia/sdk/client/api/ArchiveConnection.java
+++ b/core/src/main/java/com/opentext/ia/sdk/client/api/ArchiveConnection.java
@@ -34,6 +34,7 @@ public class ArchiveConnection {
   private String authenticationGateway;
   private String clientId;
   private String clientSecret;
+  private String scopes;
   private RestClient restClient;
 
   private String serverVersion;
@@ -109,6 +110,14 @@ public class ArchiveConnection {
 
   public void setClientId(String clientId) {
     this.clientId = clientId;
+  }
+
+  public String getScopes() {
+    return scopes;
+  }
+
+  public void setScopes(String scopes) {
+    this.scopes = scopes;
   }
 
   public String getClientSecret() {

--- a/core/src/main/java/com/opentext/ia/sdk/client/api/AuthenticationStrategyFactory.java
+++ b/core/src/main/java/com/opentext/ia/sdk/client/api/AuthenticationStrategyFactory.java
@@ -44,6 +44,7 @@ public final class AuthenticationStrategyFactory {
         () -> JwtAuthentication.optional(
             connection.getAuthenticationUser(),
             connection.getAuthenticationPassword(),
+            connection.getScopes(),
             GatewayInfo.optional(
                 connection.getAuthenticationGateway(),
                 connection.getClientId(),

--- a/core/src/main/java/com/opentext/ia/sdk/server/configuration/InfoArchiveConnectionProperties.java
+++ b/core/src/main/java/com/opentext/ia/sdk/server/configuration/InfoArchiveConnectionProperties.java
@@ -20,6 +20,7 @@ public interface InfoArchiveConnectionProperties {
   String SERVER_AUTHENTICATION_GATEWAY = SERVER_PREFIX + "authentication.gateway";
   String SERVER_CLIENT_ID = SERVER_PREFIX + "client_id";
   String SERVER_CLIENT_SECRET = SERVER_PREFIX + "client_secret";
+  String SERVER_SCOPES = SERVER_PREFIX + "scopes";
   String SERVER_URI = SERVER_PREFIX + "uri";
 
 

--- a/core/src/main/java/com/opentext/ia/sdk/server/configuration/PropertiesBasedArchiveConnection.java
+++ b/core/src/main/java/com/opentext/ia/sdk/server/configuration/PropertiesBasedArchiveConnection.java
@@ -41,6 +41,7 @@ public class PropertiesBasedArchiveConnection extends ArchiveConnection implemen
     setBillboardUri(configuration.get(SERVER_URI));
     setClientId(configuration.get(SERVER_CLIENT_ID));
     setClientSecret(configuration.get(SERVER_CLIENT_SECRET));
+    setScopes(configuration.get(SERVER_SCOPES));
     setHttpClientClassName(configuration.get(HTTP_CLIENT_CLASSNAME));
     setProxyHost(configuration.get(PROXY_HOST));
     setProxyPort(configuration.get(PROXY_PORT));


### PR DESCRIPTION
Added support for setting the OAuth scopes, this enables clients to work with OTDS and IA in case the OAuth client does not have otds:groups default scope.

- JwtAuthentication adds constructors to pass the scopes.
- If using PropertiesBasedArchiveConnection connections then the property to set the scopes is named ia.server.scopes. Value is a space separated list of scopes (if using this client with an IA with OTDS installation you need to pass otds:groups scope).